### PR TITLE
Update plugin for Spigot 1.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# mc_nobuild
+# NoBuild
+
+A simple Minecraft plugin to prevent non-admin players from placing blocks. Players can still break and collect items. Operators or players with the permission `nobuild.bypass` are exempt from this restriction.
+
+This project targets Spigot **1.21.1**.
+
+## Building
+
+Use Maven to compile the plugin:
+
+```bash
+mvn package
+```
+
+The resulting JAR will be located in `target/` and can be installed in your server's `plugins` folder.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>nobuild</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>NoBuild</name>
+  <description>Prevent non-admin users from building</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <repositories>
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot-api</artifactId>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/main/java/com/example/nobuild/NoBuild.java
+++ b/src/main/java/com/example/nobuild/NoBuild.java
@@ -1,0 +1,28 @@
+package com.example.nobuild;
+
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.EventPriority;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class NoBuild extends JavaPlugin implements Listener {
+    @Override
+    public void onEnable() {
+        getServer().getPluginManager().registerEvents(this, this);
+    }
+
+    private boolean canBuild(org.bukkit.entity.Player player) {
+        return player.isOp() || player.hasPermission("nobuild.bypass");
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (!canBuild(event.getPlayer())) {
+            event.setCancelled(true);
+            event.getPlayer().sendMessage(ChatColor.RED + "You are not allowed to build.");
+        }
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: NoBuild
+main: com.example.nobuild.NoBuild
+version: 1.0
+api-version: 1.21
+permissions:
+  nobuild.bypass:
+    description: Allows player to bypass no-build restriction
+    default: op


### PR DESCRIPTION
## Summary
- target Spigot API 1.21.1
- stop non-admins from placing blocks but allow breaking them
- mention new version in documentation

## Testing
- `apt-get install -y maven`
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847776d4874832b9e43cf5a3829e4fc