### PR TITLE
Add Makefile with build helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: compile test lint
+
+compile:
+	mvn -B package
+
+test:
+	mvn -B test
+
+lint:
+	mvn -B checkstyle:check

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Follow these steps to compile the plugin and deploy it on your Spigot server.
    - Grant the `nobuild.bypass` permission to any players who should be allowed to build.
 
 Once installed, non-operator players without the permission will be unable to place blocks, helping prevent griefing on your server.
+
+## Makefile Commands
+
+You can also use the provided Makefile for common development tasks:
+
+- `make compile` – Build the plugin JAR with Maven.
+- `make test` – Run any unit tests.
+- `make lint` – Execute Checkstyle analysis.
+


### PR DESCRIPTION
## Summary
- add `Makefile` to simplify compile, test and lint commands
- mention Makefile usage in README

## Testing
- `make lint` *(fails: No plugin found for prefix 'checkstyle')*
- `make compile` *(fails: maven-resources-plugin download failed)*
- `make test` *(fails: maven-resources-plugin download failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847889fad48832b899fb139836f03a9