### PR TITLE
Restrict building to ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # NoBuild
 
 NoBuild is a tiny **Spigot** plugin that stops regular players from placing
-blocks.  Operators (OPs) or anyone with the permission node `nobuild.bypass`
-can still build freely.  The plugin targets **Spigot 1.21.1** and is meant as a
-simple learning project.
+blocks. Only server operators (OPs) are allowed to build. The plugin targets
+**Spigot 1.21.1** and is meant as a simple learning project.
 
 Below you will find a verbose walkthrough explaining how to compile the plugin
 and install it on either a local Windows machine or an Ubuntu server such as an
@@ -82,12 +81,12 @@ about package management on Ubuntu in the
    `plugins/` directory.
 3. **Start or restart the server** – Spigot should print a message indicating
    that `NoBuild` loaded successfully.
-4. **Verify** – Use the `/plugins` command in game or in the console. You can
-   then grant the `nobuild.bypass` permission to players who should be allowed
-   to build.
+4. **Verify** – Use the `/plugins` command in game or in the console to check
+   that `NoBuild` loaded successfully. Only server operators will be able to
+   place blocks.
 
-After installation, any player without that permission will receive a red
-warning message when attempting to place blocks.  This helps keep your lobby
+After installation, any non-operator attempting to place a block will receive a
+red warning message.  This helps keep your lobby
 area tidy and free from accidental griefing.
 
 ---

--- a/src/main/java/com/example/nobuild/NoBuild.java
+++ b/src/main/java/com/example/nobuild/NoBuild.java
@@ -37,12 +37,11 @@ public class NoBuild extends JavaPlugin implements Listener {
     }
 
     // Helper method to decide if a player is allowed to place blocks.
-    // Currently it simply checks if the player is an operator or has the
-    // permission node "nobuild.bypass". You can expand this method with more
-    // complex logic, for example checking if the player is within a certain
-    // world or region.
+    // The plugin keeps things simple and only lets server operators build.
+    // WorldGuard or other protection plugins can still intervene at higher
+    // priorities if desired.
     private boolean canBuild(org.bukkit.entity.Player player) {
-        return player.isOp() || player.hasPermission("nobuild.bypass");
+        return player.isOp();
     }
 
     // Event handler that fires every time a player attempts to place a block.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,13 +6,9 @@ main: com.example.nobuild.NoBuild
 version: 1.0
 api-version: 1.21
 
-# Any permissions we define go here.  Players with 'nobuild.bypass' will be
-# allowed to place blocks. By default only server operators (OPs) have this
-# permission but you can give it to others with a permission management plugin.
-permissions:
-  nobuild.bypass:
-    description: Allows player to bypass no-build restriction
-    default: op
+# This plugin does not define any permissions. Only server operators
+# are allowed to place blocks. WorldGuard or similar plugins may still
+# impose additional restrictions on a per-region basis.
 
 # Additional ideas:
 #   You could define more permissions in the future, for example


### PR DESCRIPTION
## Summary
- limit block placement bypass to server operators only
- remove permission definition and update README docs

## Testing
- `make lint` *(fails: checkstyle plugin could not be resolved)*
- `make test` *(fails: maven resources plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684794752744832ba4e9f3e8530836b2